### PR TITLE
Validations methods change and correction of SlashCommand bug

### DIFF
--- a/Validations/DefaultValidations.cs
+++ b/Validations/DefaultValidations.cs
@@ -1,16 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DSharpPlus;
+﻿using DSharpPlus;
 using DSharpPlus.Entities;
 
 namespace Meira.Validations
 {
     internal static class DefaultValidations
     {
-        public static bool IsMeira(DiscordMember member)
+        /// <summary>
+        /// Extension method to check if Guild's member is Meira (bot).
+        /// </summary>
+        /// <param name="member"></param>
+        /// <returns></returns>
+        public static bool IsMeira(this DiscordMember member)
         {
             // This is Meira's ID
             if (member.Id == 1107789924314402836)
@@ -20,7 +20,12 @@ namespace Meira.Validations
             return false;
         }
 
-        public static bool IsAdministrator(DiscordMember member)
+        /// <summary>
+        /// Extension method to check if Guild's member is an administrator or has the permission.
+        /// </summary>
+        /// <param name="member"></param>
+        /// <returns></returns>
+        public static bool IsAdministrator(this DiscordMember member)
         {
             if (member.Permissions.HasPermission(Permissions.Administrator))
             {


### PR DESCRIPTION
### feature:
Changed the validations methods to extension methods. It's easier and faster to work.

### fixed:
Fixed the bug #2 .
The fix was adding properly validations and more specific. For  example:
```c#
if (member?.CommunicationDisabledUntil == null || member?.CommunicationDisabledUntil.Value < DateTime.Now)
``` 
It does check if CommunicationDisabledUntil is null, if this is null, probably is a bot or something that is not a human user.
If it was filled, it's going to check the value and the type of the variable is DateTime.

So I can Compare if the variable value is in fact lower than DateTime.Now.
In case of true it's going to alert, the user who use the slash command, that is impossible because the user is already free.
And in case of false, it will cancel the timeout and proceding to the previous message.